### PR TITLE
GET posts/[id] 및 recruit/[id] - 작성자가 탈퇴하였을때 오류가 나지 않도록 수정

### DIFF
--- a/app/api/posts/[id]/route.js
+++ b/app/api/posts/[id]/route.js
@@ -40,12 +40,16 @@ export async function GET(request) {
     }
   });
 
-  const user = await client.User.findUnique({
-    where: {
-      id: post.userId
-    }
-  });
-  const username = user.username;
+  let user = null;
+  let username = null;
+  if (post.userId) {
+    user = await client.User.findUnique({
+      where: {
+        id: post.userId
+      }
+    });
+    username = user.username;
+  }
 
   const result = await client.Post.findUnique({
     where: {

--- a/app/api/posts/recruit/[id]/route.js
+++ b/app/api/posts/recruit/[id]/route.js
@@ -44,17 +44,20 @@ export async function GET(request) {
     });
   }
 
-  const leader = await client.JoinedClub.findUnique({
-    where: {
-      userId_clubId: {
-        userId: session.userId,
-        clubId: myPost.clubId
+  let leader = null;
+  if (myPost.userId) {
+    leader = await client.JoinedClub.findUnique({
+      where: {
+        userId_clubId: {
+          userId: session.userId,
+          clubId: myPost.clubId
+        }
+      },
+      select: {
+        isLeader: true
       }
-    },
-    select: {
-      isLeader: true
-    }
-  });
+    });
+  }
 
   if (!leader || !leader.isLeader) {
     return NextResponse.json({


### PR DESCRIPTION
특정 글의 작성자가 탈퇴하였을 때 해당 글에 GET을 시도할 경우, 해당 글에서 작성자를 가져오려고 시도하다 오류가 발생할 수도 있었던 문제를 수정한 PR입니다. GET posts/[id]의 경우 작성자가 없다면 'username'은 null로 보고됩니다.