### PR TITLE
GET posts/notice - createdAt 기준 내림차순으로 정렬

### DIFF
--- a/app/api/posts/notice/route.js
+++ b/app/api/posts/notice/route.js
@@ -16,7 +16,8 @@ export async function GET(request) {
       select: {
         id: true,
         title: true,
-        updatedAt: true
+        updatedAt: true,
+        createdAt: true
       }
     });
     return NextResponse.json(result);


### PR DESCRIPTION
이제 공지가 가장 최근에 작성된 것부터 순서대로 표시됩니다.