### PR TITLE
PATCH admin/clubs/[id] 수정

### DIFF
--- a/app/admin/clubleader/page.js
+++ b/app/admin/clubleader/page.js
@@ -26,7 +26,7 @@ export default function clubLeader() {
       })
     });
 
-    if (res.status == 200) {
+    if (res.status == 201) {
       return router.push('/admin');
     }
     else if (res.status == 204) {
@@ -34,7 +34,7 @@ export default function clubLeader() {
       return router.push('/');
     }
     else if (res.status == 400) {
-      alert('잘못된 값이 입력되었습니다.');
+      alert((await res.json()).message);
       return router.push('/');
     }
     else if (res.status == 401) {

--- a/app/api/admin/clubs/[id]/route.js
+++ b/app/api/admin/clubs/[id]/route.js
@@ -135,6 +135,13 @@ export async function PATCH(request) {
         }
       });
     }
+    else if (curLeader[0].userId == user.id) {
+      return NextResponse.json({
+        message: "이미 권한을 가진 사용자입니다."
+      }, {
+        status: 400,
+      });
+    }
     else {
       await client.JoinedClub.update({
         where: {


### PR DESCRIPTION
소유권 이전 중복 시의 버그 수정

# ⚠️ 연관된 이슈

> 현재 PR로 이슈를 'close'하고 싶을 때: `close #이슈번호` <br> 'close'하지 않고 연관된 이슈만 적고 싶을 때: `#이슈번호`

close #58

# 🔨 작업 내용

> 도메인: 관련 URL(Frontend), API 주소(BackEnd), Schema 등

### 도메인: `/api/admin/clubs/[id]`
- 유저 A가 소유권을 가진 동아리 B를, 다시 유저 A에게 소유권 이전을 시도 시 유저 A의 소유권이 박탈당했음.
- 이를 막기 위해, 소유권을 이미 가진 사람에게 소유권 이전을 시도할 경우 400 오류를 반환하도록 함.

# 💬 추가 사항

> 개발한 기능이 아닌 추가적으로 전달하고 싶은 말

해당 API는 관리자가 소유한 동아리를 이전 시에는 관리자가 더 이상 해당 동아리에 속하지 않도록 합니다. (joinedclub에서 삭제)
그러나 일반 유저 A가 소유한 동아리를 일반 유저 B에게 이전 시, A는 여전히 해당 동아리에 속하며 소유권만 B에게 이전됩니다. (isLeader 값만 변경)
이 부분을 계속 유지해도 되는지 확인해야 할 것 같습니다.