### PR TITLE
fix: subcategories(mainCategory) 예외처리

### DIFF
--- a/app/hooks/college.js
+++ b/app/hooks/college.js
@@ -34,12 +34,17 @@ export function mainCategory() {
  */
 export function subcategories(mainCategory) {
   const result = {};
-  Object.entries(College[mainCategory]).sort((a,b)=>{
-    if (a[1] < b[1]) return -1;
-    return 1;
-  }).forEach(([k, value]) => {
-    result[k] = value;
-  });
+  try {
+    Object.entries(College[mainCategory]).sort((a,b)=>{
+      if (a[1] < b[1]) return -1;
+      return 1;
+    }).forEach(([k, value]) => {
+      result[k] = value;
+    });
+  } catch (e) {
+    console.error(e);
+    return undefined;
+  }
   delete result.name;
   return result;
 }


### PR DESCRIPTION
# ⚠️ 연관된 이슈

> 현재 PR로 이슈를 'close'하고 싶을 때: `close #이슈번호` <br> 'close'하지 않고 연관된 이슈만 적고 싶을 때: `#이슈번호`

close #57 

# 🔨 작업 내용

> 도메인: 관련 URL(Frontend), API 주소(BackEnd), Schema 등

### 도메인: `X`
- subcategories('KOR')과 같이 단과대학이 아닌 학과가 들어가면 에러를 발생시켜 해당 페이지 렌더링이 불가
- 아래 이미지와 같이 렌더링 허용 및 undefined 반환 & 에러 로그 출력으로 변경

# 🖼️ 참고 이미지 및 영상

![image](https://github.com/user-attachments/assets/cdf2874f-1532-463f-9204-cae07ad79df1)
