### PR TITLE
alwaysrecruit

### DIFF
--- a/app/club/[id]/page.js
+++ b/app/club/[id]/page.js
@@ -25,6 +25,7 @@ export default function club({ params }) {
     });
     if (rows.status == 200) {
       const jsonData = await rows.json();
+      console.log('Fetched Club Data', jsonData);
       setClub(jsonData);
 
       if (jsonData.image) {
@@ -94,6 +95,7 @@ export default function club({ params }) {
     }
   }
 
+
   return (
     <div className={Styles.Container}>
       <h1 className={Styles.PageTitle}>동아리</h1>
@@ -153,7 +155,14 @@ export default function club({ params }) {
               <div className={Styles.RecruitBox}>
                 <div className={Styles.RecruitInner}>
                   <button>모집 기간</button>
-                  <p>{getDate(Club.post.recruit.recruitStart)} ~ {getDate(Club.post.recruit.recruitEnd)}</p>
+                  {(
+
+                    getDate(Club.post?.recruit?.recruitEnd).trim() === '9999-12-31' ? (
+                    <p>상시 모집</p>
+                  ) : (
+                    <p>{getDate(Club.post.recruit.recruitStart)} ~ {getDate(Club.post.recruit.recruitEnd)}</p>
+                    )
+                  )}
                 </div>
                 {
                   Club.post.recruit.recruitTarget.length > 2 ?

--- a/app/component/ClubInList.js
+++ b/app/component/ClubInList.js
@@ -141,7 +141,12 @@ export default function dongariInList({club, i}) {
             <div className={Styles.ShortBlock}>
               <h4 id={"info2"+i} className={Styles.BlueButton}>모집 기간</h4>
               <div className={Styles.InfoText}>
-                <span>{`${getDate(recruit.recruitStart)} ~ ${getDate(recruit.recruitEnd)}`}</span>
+                {getDate(recruit.recruitEnd) === '9999-12-31' ?  (
+                  <span>상시 모집</span>
+                ) : (
+                  <span>{`${getDate(recruit.recruitStart)} ~ ${getDate(recruit.recruitEnd)}`}</span>
+                )}
+        
               </div>
             </div> : null
           }

--- a/app/my/recruit/[id]/page.js
+++ b/app/my/recruit/[id]/page.js
@@ -87,15 +87,13 @@ export default function recruit({params}) {
         newPostOrigin.recruit.recruitStart = post.recruit.recruitStart.slice(0, 10);
         setRecruitEnd(post.recruit.recruitEnd.slice(0, 10));
         newPostOrigin.recruit.recruitEnd = post.recruit.recruitEnd.slice(0, 10);
-        setIsAlwaysRecruit(post.recruit.recruitEnd == '9999-12-31');
 
-        if(recruitEnd === '9999-12-31') {
+        if(post.recruit.recruitEnd === '9999-12-31T00:00:00.000Z') {
           setIsAlwaysRecruit(true);
           setRecruitEnd('9999-12-31');
         } else {
           setIsAlwaysRecruit(false);
         }
-
         setRecruitTarget(JSON.parse(post.recruit.recruitTarget));
         newPostOrigin.recruit.recruitTarget = post.recruit.recruitTarget;
         if (post.recruit.recruitURL) {
@@ -289,6 +287,8 @@ export default function recruit({params}) {
     GetClub();
   }, []);
 
+  
+
   return (
     <div className={Styles.Container}>
       <h1 className={Styles.PageTitle}>동아리 모집 공고 수정</h1>
@@ -344,6 +344,7 @@ export default function recruit({params}) {
               id='recruitStart'
               value={recruitStart}
               disabled={IsAlwaysRecruiting}
+              style={IsAlwaysRecruiting ? {color:'transparent'} : undefined}
               onChange={(e) => {
                 setRecruitStart(e.target.value);
                 if (new Date(e.target.value) < new Date(toStringByFormatting(new Date())))
@@ -364,11 +365,12 @@ export default function recruit({params}) {
               }
               value={recruitEnd}
               disabled={IsAlwaysRecruiting}
+              style={IsAlwaysRecruiting ? {color: 'transparent'} : undefined}
               onChange={(e) => setRecruitEnd(e.target.value)}
             />
           </div>
 
-          <label>
+          
             <p className={Styles.Left}>상시 모집</p>
               <input
                 type='checkbox'
@@ -385,7 +387,7 @@ export default function recruit({params}) {
                   }
                 }}
               />
-            </label>
+            
 
         </label>
 

--- a/app/my/recruit/[id]/page.js
+++ b/app/my/recruit/[id]/page.js
@@ -87,6 +87,15 @@ export default function recruit({params}) {
         newPostOrigin.recruit.recruitStart = post.recruit.recruitStart.slice(0, 10);
         setRecruitEnd(post.recruit.recruitEnd.slice(0, 10));
         newPostOrigin.recruit.recruitEnd = post.recruit.recruitEnd.slice(0, 10);
+        setIsAlwaysRecruit(post.recruit.recruitEnd == '9999-12-31');
+
+        if(recruitEnd === '9999-12-31') {
+          setIsAlwaysRecruit(true);
+          setRecruitEnd('9999-12-31');
+        } else {
+          setIsAlwaysRecruit(false);
+        }
+
         setRecruitTarget(JSON.parse(post.recruit.recruitTarget));
         newPostOrigin.recruit.recruitTarget = post.recruit.recruitTarget;
         if (post.recruit.recruitURL) {
@@ -118,6 +127,7 @@ export default function recruit({params}) {
 
   const [recruitStart, setRecruitStart] = useState(toStringByFormatting(new Date()))
   const [recruitEnd, setRecruitEnd] = useState(toStringByFormatting(new Date()))
+  const [IsAlwaysRecruiting, setIsAlwaysRecruit] = useState(false);
 
   const [recruitURL, setURL] = useState('');
 
@@ -169,6 +179,8 @@ export default function recruit({params}) {
   const [content, setContent] = useState('');
 
   const submitHandler = async (e) => {
+    e.preventDefault();
+
     const clubID = selectClub;
     const toBody = {};
 
@@ -331,6 +343,7 @@ export default function recruit({params}) {
               type='date'
               id='recruitStart'
               value={recruitStart}
+              disabled={IsAlwaysRecruiting}
               onChange={(e) => {
                 setRecruitStart(e.target.value);
                 if (new Date(e.target.value) < new Date(toStringByFormatting(new Date())))
@@ -350,10 +363,34 @@ export default function recruit({params}) {
                 recruitStart
               }
               value={recruitEnd}
+              disabled={IsAlwaysRecruiting}
               onChange={(e) => setRecruitEnd(e.target.value)}
             />
           </div>
+
+          <label>
+            <p className={Styles.Left}>상시 모집</p>
+              <input
+                type='checkbox'
+                id='AlwalysRecruiting'
+                checked={IsAlwaysRecruiting}
+                onChange={(e) => {
+                  setIsAlwaysRecruit(e.target.checked);
+                  if(e.target.checked) {
+                    setRecruitStart(toStringByFormatting(new Date()));
+                    setRecruitEnd('9999-12-31');
+                  }else{
+                    setRecruitStart(toStringByFormatting(new Date()));
+                    setRecruitEnd(toStringByFormatting(new Date()));
+                  }
+                }}
+              />
+            </label>
+
         </label>
+
+        
+
 
         <label className={Styles.HorizonBox}>
           <p className={Styles.Left}>신청 링크</p>

--- a/app/recruit/page.js
+++ b/app/recruit/page.js
@@ -284,7 +284,7 @@ export default function recruit() {
               style={IsAlwaysRecruiting ? {color : 'transparent'} : undefined}
               onChange={(e) => setRecruitEnd(e.target.value)}
             />
-            <label>
+            
             <p className={Styles.Left}>상시 모집</p>
               <input
                 type='checkbox'
@@ -301,7 +301,7 @@ export default function recruit() {
                   }
                 }}
               />
-            </label>
+            
           </div>
         </label>
 

--- a/app/recruit/page.js
+++ b/app/recruit/page.js
@@ -260,6 +260,7 @@ export default function recruit() {
               id='recruitStart'
               value={recruitStart}
               disabled={IsAlwaysRecruiting}
+              style={IsAlwaysRecruiting ? {color:'transparent'} : undefined}
               onChange={(e) => {
                 setRecruitStart(e.target.value);
                 if (new Date(e.target.value) < new Date(toStringByFormatting(new Date())))
@@ -280,6 +281,7 @@ export default function recruit() {
               }
               value={recruitEnd}
               disabled={IsAlwaysRecruiting}
+              style={IsAlwaysRecruiting ? {color : 'transparent'} : undefined}
               onChange={(e) => setRecruitEnd(e.target.value)}
             />
             <label>

--- a/app/recruit/page.js
+++ b/app/recruit/page.js
@@ -70,6 +70,16 @@ export default function recruit() {
 
   const [recruitStart, setRecruitStart] = useState(toStringByFormatting(new Date()))
   const [recruitEnd, setRecruitEnd] = useState(toStringByFormatting(new Date()))
+  const [IsAlwaysRecruiting, setIsAlwaysRecruit] = useState(false);
+// 상시모집 상태 정의
+
+  useEffect(() => {
+    if (recruitEnd === '9999-12-31'){
+      setIsAlwaysRecruit(true);
+    }else{
+      setIsAlwaysRecruit(false);
+    }
+  }, [recruitEnd]);
 
   const [recruitURL, setURL] = useState('');
 
@@ -249,6 +259,7 @@ export default function recruit() {
               type='date'
               id='recruitStart'
               value={recruitStart}
+              disabled={IsAlwaysRecruiting}
               onChange={(e) => {
                 setRecruitStart(e.target.value);
                 if (new Date(e.target.value) < new Date(toStringByFormatting(new Date())))
@@ -268,8 +279,27 @@ export default function recruit() {
                 recruitStart
               }
               value={recruitEnd}
+              disabled={IsAlwaysRecruiting}
               onChange={(e) => setRecruitEnd(e.target.value)}
             />
+            <label>
+            <p className={Styles.Left}>상시 모집</p>
+              <input
+                type='checkbox'
+                id='AlwalysRecruiting'
+                checked={IsAlwaysRecruiting}
+                onChange={(e) => {
+                  setIsAlwaysRecruit(e.target.checked);
+                  if(e.target.checked) {
+                    setRecruitStart(toStringByFormatting(new Date()));
+                    setRecruitEnd('9999-12-31');
+                  }else{
+                    setRecruitStart(toStringByFormatting(new Date()));
+                    setRecruitEnd(toStringByFormatting(new Date()));
+                  }
+                }}
+              />
+            </label>
           </div>
         </label>
 


### PR DESCRIPTION
# ⚠️ 연관된 이슈

> close #60 

# 🔨 작업 내용

> 도메인: 관련 URL(Frontend), API 주소(BackEnd), Schema 등

### 도메인: `/recruit`, `/club\[id]`, `my\recruit/[id]`
- 모집공고 등록 시 상시모집 버튼 생성 ; 상시모집 버튼을 누르면 날짜 선택 기능이 없어지며 모집시작일은 등록일, 모집종료일은 9999-12-31으로 뜬다. 
-  모집공고 수정 시 상시모집 
- 동아리 찾기 및 자세히 보기에서 상시모집 중인 동아리면 모집 기간에 상시모집이라고 뜬다.
* 상시 모집 중인 동아리일 때는 모집 기간 날짜가 투명색으로 바뀜.

# 🖼️ 참고 이미지 및 영상

> (선택)

# 💬 추가 사항

> 개발한 기능이 아닌 추가적으로 전달하고 싶은 말

완벽합니다.